### PR TITLE
Reorganised layout in preparation for multiple diagrams

### DIFF
--- a/src/main/java/org/brokn/sequence/gui/SequenceDialog.form
+++ b/src/main/java/org/brokn/sequence/gui/SequenceDialog.form
@@ -9,26 +9,18 @@
     </properties>
     <border type="none"/>
     <children>
-      <grid id="8e27c" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
+      <grid id="8e27c" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints border-constraint="Center"/>
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="e3588" layout-manager="GridBagLayout">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-            </constraints>
+          <grid id="e3588" layout-manager="BorderLayout" hgap="0" vgap="0">
+            <constraints border-constraint="Center"/>
             <properties/>
             <border type="none"/>
             <children>
               <toolbar id="dfd82">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="-1" height="20"/>
-                  </grid>
-                  <gridbag weightx="0.0" weighty="0.0"/>
-                </constraints>
+                <constraints border-constraint="North"/>
                 <properties>
                   <preferredSize width="300" height="60"/>
                 </properties>
@@ -64,7 +56,7 @@
                       <verticalTextPosition value="3"/>
                     </properties>
                   </component>
-                  <component id="170fc" class="javax.swing.JSlider" binding="slider1" default-binding="true">
+                  <component id="170fc" class="javax.swing.JSlider" binding="scaleSlider">
                     <constraints/>
                     <properties>
                       <maximum value="10"/>
@@ -79,68 +71,51 @@
                   </hspacer>
                 </children>
               </toolbar>
-              <splitpane id="e92c2">
-                <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                    <preferred-size width="200" height="200"/>
-                  </grid>
-                  <gridbag weightx="1.0" weighty="1.0"/>
-                </constraints>
+              <tabbedpane id="a050a" binding="tabContainer">
+                <constraints border-constraint="Center"/>
                 <properties/>
                 <border type="none"/>
                 <children>
-                  <grid id="4458f" binding="canvasContainer" custom-create="true" layout-manager="BorderLayout" hgap="0" vgap="0">
+                  <splitpane id="e92c2">
                     <constraints>
-                      <splitpane position="right"/>
-                    </constraints>
-                    <properties/>
-                    <border type="none"/>
-                    <children/>
-                  </grid>
-                  <grid id="ae3a0" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                    <margin top="0" left="0" bottom="0" right="0"/>
-                    <constraints>
-                      <splitpane position="left"/>
+                      <tabbedpane title="Untitled"/>
                     </constraints>
                     <properties/>
                     <border type="none"/>
                     <children>
-                      <tabbedpane id="817af" binding="tabbedPane1" default-binding="true">
+                      <grid id="4458f" binding="canvasContainer" custom-create="true" layout-manager="BorderLayout" hgap="0" vgap="0">
                         <constraints>
-                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                            <preferred-size width="200" height="200"/>
-                          </grid>
+                          <splitpane position="right"/>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children/>
+                      </grid>
+                      <grid id="ae3a0" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                        <margin top="0" left="0" bottom="0" right="0"/>
+                        <constraints>
+                          <splitpane position="left"/>
                         </constraints>
                         <properties/>
                         <border type="none"/>
                         <children>
-                          <grid id="5eee8" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                            <margin top="0" left="0" bottom="0" right="0"/>
+                          <component id="95d32" class="javax.swing.JTextArea" binding="textArea1" default-binding="true">
                             <constraints>
-                              <tabbedpane title="Untitled"/>
+                              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                                <preferred-size width="150" height="50"/>
+                              </grid>
                             </constraints>
-                            <properties/>
-                            <border type="none"/>
-                            <children>
-                              <component id="95d32" class="javax.swing.JTextArea" binding="textArea1" default-binding="true">
-                                <constraints>
-                                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                                    <preferred-size width="150" height="50"/>
-                                  </grid>
-                                </constraints>
-                                <properties>
-                                  <focusCycleRoot value="true"/>
-                                  <font name="Courier New" size="12" style="0"/>
-                                </properties>
-                              </component>
-                            </children>
-                          </grid>
+                            <properties>
+                              <focusCycleRoot value="true"/>
+                              <font name="Courier New" size="12" style="0"/>
+                            </properties>
+                          </component>
                         </children>
-                      </tabbedpane>
+                      </grid>
                     </children>
-                  </grid>
+                  </splitpane>
                 </children>
-              </splitpane>
+              </tabbedpane>
             </children>
           </grid>
         </children>

--- a/src/main/java/org/brokn/sequence/gui/SequenceDialog.java
+++ b/src/main/java/org/brokn/sequence/gui/SequenceDialog.java
@@ -20,10 +20,10 @@ public class SequenceDialog extends JFrame {
     private JButton buttonExport;
     private JTextArea textArea1;
     private JPanel canvasContainer;
-    private JTabbedPane tabbedPane1;
     private JButton buttonSave;
     private JButton buttonOpen;
-    private JSlider slider1;
+    private JSlider scaleSlider;
+    private JTabbedPane tabContainer;
 
     public SequenceDialog() {
         super("Sequencer");
@@ -53,7 +53,7 @@ public class SequenceDialog extends JFrame {
         });
         buttonOpen.addActionListener(e -> openFile());
 
-        slider1.addChangeListener(e -> ((Canvas) canvasContainer).updateScale(((JSlider) e.getSource()).getValue()));
+        scaleSlider.addChangeListener(e -> ((Canvas) canvasContainer).updateScale(((JSlider) e.getSource()).getValue()));
     }
 
     private void openFile() {


### PR DESCRIPTION
Moved the tabContainer up a level so that it contains the split panel, which contains both the text area and the canvas